### PR TITLE
fix minor issue in /archive and adding a custom date range

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,10 +31,10 @@ def crawl_soup(url: str) -> BeautifulSoup:
     return soup
 
 
-def merge_and_extract_tables(table_soup):
+def merge_and_extract_tables(tables_soup):
     tables = []
-    for i in range(len(table_soup)):
-        for tr in table_soup[i].find_all("tr")[1:]:
+    for table_soup in tables_soup:
+        for tr in table_soup.find_all("tr")[1:]:
             table = []
             for td in tr.find_all("td"):
                 table.append(td.text)

--- a/main.py
+++ b/main.py
@@ -110,7 +110,7 @@ async def read_latest():
 
 @app.get("/archive/range")
 @cache(expire=60 * 60 * 24)
-async def customrange(startDate: str = (datetime.date.today() - datetime.timedelta(days=1)).strftime("%Y-%m-%d"), endDate: str = datetime.date.today().strftime("%Y-%m-%d")):
+async def read_archive_range(start_date: str, end_date: str = datetime.date.today().strftime("%Y-%m-%d")):
     try:
         startDate = datetime.datetime.strptime(startDate, "%Y-%m-%d")
         endDate = datetime.datetime.strptime(endDate, "%Y-%m-%d")

--- a/main.py
+++ b/main.py
@@ -112,21 +112,21 @@ async def read_latest():
 @cache(expire=60 * 60 * 24)
 async def read_archive_range(start_date: str, end_date: str = datetime.date.today().strftime("%Y-%m-%d")):
     try:
-        startDate = datetime.datetime.strptime(startDate, "%Y-%m-%d")
-        endDate = datetime.datetime.strptime(endDate, "%Y-%m-%d")
+        start_date = datetime.datetime.strptime(start_date, "%Y-%m-%d")
+        end_date = datetime.datetime.strptime(end_date, "%Y-%m-%d")
     except ValueError:
         raise HTTPException(
             status_code=422, detail="Invalid Date format. Expected YYYY-MM-DD")
 
-    priceRange = {}
-    duration = endDate - startDate
+    price_range = {}
+    duration = end_date - start_date
 
     for i in range(duration.days + 1):
-        day = startDate + datetime.timedelta(days=i)
+        day = start_date + datetime.timedelta(days=i)
         price = await read_archive(day.strftime("%Y-%m-%d"))
         price.pop("date")
-        priceRange[day.strftime("%Y-%m-%d")] = price
-    return priceRange
+        price_range[day.strftime("%Y-%m-%d")] = price
+    return price_range
 
 
 @app.on_event("startup")

--- a/main.py
+++ b/main.py
@@ -70,11 +70,16 @@ async def read_archive(date: str = (datetime.date.today() - datetime.timedelta(d
             status_code=422, detail="Invalid Date format. Expected YYYY-MM-DD")
 
     soup = crawl_soup(BONBAST_URL + "/archive" + date.strftime("/%Y/%m/%d"))
-    table_soup = soup.find("table")
-    table = [[td.text for td in tr.findAll("td")]
-             for tr in table_soup.findAll("tr")[1:]]
+    table_soup = soup.find_all("table")
+    tables = []
+    for i in range(len(table_soup)-1):
+        for tr in table_soup[i].find_all("tr")[1:]:
+            table = []
+            for td in tr.find_all("td"):
+                table.append(td.text)
+            tables.append(table)
     prices = {"date": date.strftime("%Y-%m-%d")}
-    for row in table:
+    for row in tables:
         try:
             currency = row[0].lower()
             sell, buy = int(row[2]), int(row[3])
@@ -114,11 +119,16 @@ async def read_archive(startDate: str = (datetime.date.today() - datetime.timede
     for i in range(duration.days + 1):
         day = startDate + datetime.timedelta(days=i)
         soup = crawl_soup(BONBAST_URL + "/archive" + day.strftime("/%Y/%m/%d"))
-        table_soup = soup.find("table")
-        table = [[td.text for td in tr.findAll("td")]
-                 for tr in table_soup.findAll("tr")[1:]]
+        table_soup = soup.find_all("table")
+        tables = []
+        for i in range(len(table_soup)-1):
+            for tr in table_soup[i].find_all("tr")[1:]:
+                table = []
+                for td in tr.find_all("td"):
+                    table.append(td.text)
+                tables.append(table)
         date = {}
-        for row in table:
+        for row in tables:
             try:
                 currency = row[0].lower()
                 sell, buy = int(row[2]), int(row[3])


### PR DESCRIPTION
1. There was an issue in `/archive` that resulted in an incomplete representation of the currencies, which was fixed by iterating on all the tables on the archive page.
2. A new endpoint was added to accept custom date ranges;`/customrange` that can be accessed by sending the `startDate` and `endDate` params. 